### PR TITLE
Compatibility for Western Clothes: Redux

### DIFF
--- a/common/scripted_triggers/00_WCR_COM_triggers.txt
+++ b/common/scripted_triggers/00_WCR_COM_triggers.txt
@@ -1,0 +1,49 @@
+﻿# Triggers dedicated to driving seamless compatibility with Western Clothes: Redux
+#
+# ################
+# # By 1230james #
+# ################
+#
+# File last updated: 2024-03-21
+# See WCR's copy for latest documentation
+#     https://steamcommunity.com/sharedfiles/filedetails/?id=2981574864
+#     https://github.com/1230james/vic3-western-clothes
+#
+# ==================================================================================================================== #
+#
+# COM_WCR_enable_outfit
+#     When true, signals intent to have an outfit be enabled; i.e., WCR is not trying to apply an outfit and is
+#     expecting COM to provide one. 
+#
+# COM_WCR_disable_outfit
+#     When true, signals intent to have an outfit be disabled; i.e., WCR is trying to apply its own outfit and wants
+#     COM to not apply a potentially conflicting outfit.
+#
+# Both triggers should be implemented directly in the modifier block of an outfit. No other checks with regards to
+# country, character/pop, etc. are needed by COM and WCR will handle that on its end. Best usage for both triggers would
+# be to use them in separate modifier blocks away from the normal logic (unless if otherwise acceptable). Either trigger
+# returning false should be interpreted as WCR not wishing to interrupt the functionality of COM, and trigger logic
+# should be set up such that either trigger returning false has zero impact on any outfits the triggers are used in.
+#
+# ==================================================================================================================== #
+#
+# List of WCR-controlled COM outfits:
+#   Monarchs
+#     Korea
+#     Japan
+#
+#   Militaries
+#     None
+#
+# ==================================================================================================================== #
+
+# Implementations here MUST always be `always = no` for proper functionality.
+# WCR will overwrite with actual logic if the mod is installed.
+
+COM_WCR_enable_outfit = {
+    always = no
+}
+
+COM_WCR_disable_outfit = {
+    always = no
+}

--- a/gfx/portraits/portrait_modifiers/com_clothes.txt
+++ b/gfx/portraits/portrait_modifiers/com_clothes.txt
@@ -2058,6 +2058,16 @@ COM_clothes = {
                     }
                 }
             }
+            
+            # WCR compatibility
+            modifier = {
+                add = 1000
+                COM_WCR_enable_outfit = yes
+            }
+            modifier = {
+                add = -1000
+                COM_WCR_disable_outfit = yes
+            }
         }
     }
 
@@ -2173,6 +2183,16 @@ COM_clothes = {
                         age >= 10
                     }
                 }
+            }
+            
+            # WCR compatibility
+            modifier = {
+                add = 1000
+                COM_WCR_enable_outfit = yes
+            }
+            modifier = {
+                add = -1000
+                COM_WCR_disable_outfit = yes
             }
         }
     }


### PR DESCRIPTION
Adds two new scripted triggers to be inserted into any clothing definition that WCR should be given control over and added them to the clothing definitions of the Korean and Japanese emperor outfits. This will allow to seamless compatibility between the two mods [from the user's perspective] and will make future compatibility updates simple.